### PR TITLE
67 hex cache

### DIFF
--- a/Dockerfile_app.REPLACE
+++ b/Dockerfile_app.REPLACE
@@ -37,7 +37,6 @@ RUN apt-get update && apt-get install -y \
 RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.1.1/zsh-in-docker.sh)"
 
 RUN pip3 install \
-    awscli \
     dagster==1.0.12 \
     dagit==1.0.12 \
     dagster-graphql==1.0.12 \

--- a/discursus_data_platform/assets/dw_assets.py
+++ b/discursus_data_platform/assets/dw_assets.py
@@ -114,7 +114,7 @@ def hex_project_refresh(context):
     hex_output: HexOutput = context.resources.hex_resource.run_and_poll(
         project_id = "d6824152-38b4-4f39-8f5e-c3a963cc48c8",
         inputs = {},
-        update_cache = False,
+        update_cache = True,
         kill_on_timeout = True,
         poll_interval = DEFAULT_POLL_INTERVAL,
         poll_timeout = None,

--- a/discursus_data_platform/assets/dw_assets.py
+++ b/discursus_data_platform/assets/dw_assets.py
@@ -113,7 +113,7 @@ def dw_clean_up(context):
 def hex_project_refresh(context):
     hex_output: HexOutput = context.resources.hex_resource.run_and_poll(
         project_id = "d6824152-38b4-4f39-8f5e-c3a963cc48c8",
-        inputs = {},
+        inputs = None,
         update_cache = True,
         kill_on_timeout = True,
         poll_interval = DEFAULT_POLL_INTERVAL,


### PR DESCRIPTION
# Description

Fixes #67 

# Lineage changes

None

# Type of change

Please select option that is relevant.

- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Infrastructure (provides the necessary resources for platform to run)

# Checklist:

- [x] My pull request represents one story (logical piece of work).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran the data platform in my development environment without error.
- [x] I ran the data pipelines in my development environment without error.
- [x] I updated the README file with up-to-date asset lineage graphs, data wareohouse DAG and ERD

## To produce README graphs
Asset lineage graphs
- Run the data platform locally
- Click on Assets in the top-right menu
- Click on View global asset lineage
- Screen capture the lineage
- Save to `./resources/images/asset_lineage_graph.png`

Data warehouse ERD
- `cd ./semantics`
- `droughty dbml --profile-dir ./droughty_profiles.yml --project-dir ./droughty_projects.yml`
- `dbdocs build dbml/discursus_analytics.dbml`
- Go to link provided as output to previous command
- Click on Relationships in top menu
- Click on Download util and export to png
- Save to `./resources/images/dw_erd.png`

Data Warehouse DAG
- `cd ./discursus_data_platform/dw/`
- `dbt docs generate --profiles-dir ./`
- `dbt docs serve --profiles-dir ./`
- Once on the local dbt documentations website, click on the View Lineage Graph icon at bottom right
- Unselect the `analysis` resources
- Screen capture the DAG
- Save to `./resources/images/dw_dag.png`